### PR TITLE
Bump nuspec version to 1.0.22

### DIFF
--- a/src/BundlerMinifier/MSBuild/BuildBundlerMinifier.nuspec
+++ b/src/BundlerMinifier/MSBuild/BuildBundlerMinifier.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>BuildBundlerMinifier</id>
-        <version>1.0.21</version>
+        <version>1.0.22</version>
         <title>Bundler &amp; Minifier</title>
         <authors>Mads Kristensen</authors>
         <owners>Mads Kristensen</owners>


### PR DESCRIPTION
From 1.0.21, to incorporate build order change.
